### PR TITLE
chewing is not enabled right after installation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,6 @@ set( fcitx_chewing_sources
 add_definitions( -DLOCALEDIR=\"${CMAKE_INSTALL_PREFIX}/share/locale\" )
 
 fcitx_add_addon_full(chewing
-DESC
 SOURCES ${fcitx_chewing_sources}
 IM_CONFIG chewing.conf
 LINK_LIBS ${CHEWING_LIBRARIES})


### PR DESCRIPTION
I am still not sure what caused this since I do not keep track of the most recent update of fcitx cmake.
But this might be it.
