### PR TITLE
Add Carpalx keyboard layout support

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -26,22 +26,22 @@ msgstr "1234567890"
 msgid "1234qweras"
 msgstr "1234qweras"
 
-#: src/fcitx-chewing.desc:15
+#: src/fcitx-chewing.desc:16
 msgid "Add Phrase Forward"
 msgstr ""
 
-#: src/fcitx-chewing.desc:25
+#: src/fcitx-chewing.desc:26
 msgid "Automatically shift cursor"
 msgstr "Cursor automatisch anheben"
 
-#: src/fcitx-chewing.desc:20
+#: src/fcitx-chewing.desc:21
 msgid "Backward phrase choice"
 msgstr ""
 
 #: src/eim.c:148 src/chewing.conf.in:3 src/fcitx-chewing.conf.in:3
-#: src/fcitx-chewing.desc:1 src/fcitx-chewing.desc:13 src/fcitx-chewing.desc:18
-#: src/fcitx-chewing.desc:23 src/fcitx-chewing.desc:28
-#: src/fcitx-chewing.desc:33
+#: src/fcitx-chewing.desc:1 src/fcitx-chewing.desc:14 src/fcitx-chewing.desc:19
+#: src/fcitx-chewing.desc:24 src/fcitx-chewing.desc:29
+#: src/fcitx-chewing.desc:34
 msgid "Chewing"
 msgstr "Chewing"
 
@@ -49,47 +49,47 @@ msgstr "Chewing"
 msgid "Chewing Wrapper For Fcitx"
 msgstr "Chewing Wrapper für Fcitx"
 
-#: src/fcitx-chewing.desc:46
+#: src/fcitx-chewing.desc:47
 msgid "DACHEN_CP26 Keyboard"
 msgstr "DACHEN_CP26 Tastatur"
 
-#: src/fcitx-chewing.desc:38
+#: src/fcitx-chewing.desc:39
 msgid "Default Keyboard"
 msgstr "Standard Tastatur"
 
-#: src/fcitx-chewing.desc:44
+#: src/fcitx-chewing.desc:45
 msgid "Dvorak Keyboard"
 msgstr "Dvorak Tastatur"
 
-#: src/fcitx-chewing.desc:45
+#: src/fcitx-chewing.desc:46
 msgid "Dvorak Keyboard with Hsu's support"
 msgstr "Dvorak Keyboard mit Hsu's Unterstützung"
 
-#: src/fcitx-chewing.desc:42
+#: src/fcitx-chewing.desc:43
 msgid "ETen Keyboard"
 msgstr "ETen Tastatur"
 
-#: src/fcitx-chewing.desc:43
+#: src/fcitx-chewing.desc:44
 msgid "ETen26 Keyboard"
 msgstr "ETen26 Tastatur"
 
-#: src/fcitx-chewing.desc:41
+#: src/fcitx-chewing.desc:42
 msgid "Gin-Yieh Keyboard"
 msgstr "Gin-Yieh Tastatur"
 
-#: src/fcitx-chewing.desc:47
+#: src/fcitx-chewing.desc:48
 msgid "Han-Yu PinYin Keyboard"
 msgstr "Han-Yu PinYin Tastatur"
 
-#: src/fcitx-chewing.desc:39
+#: src/fcitx-chewing.desc:40
 msgid "Hsu's Keyboard"
 msgstr "Hsu's Tastatur"
 
-#: src/fcitx-chewing.desc:40
+#: src/fcitx-chewing.desc:41
 msgid "IBM Keyboard"
 msgstr "IBM Tastatur"
 
-#: src/fcitx-chewing.desc:35
+#: src/fcitx-chewing.desc:36
 msgid "Keyboard Layout"
 msgstr "Tastaturlayout"
 
@@ -97,7 +97,7 @@ msgstr "Tastaturlayout"
 msgid "Selection Key"
 msgstr "Auswahltaste"
 
-#: src/fcitx-chewing.desc:30
+#: src/fcitx-chewing.desc:31
 msgid "Space as selection key"
 msgstr "SPACE als Auswahltaste"
 
@@ -116,3 +116,11 @@ msgstr "asdfjkl789"
 #: src/fcitx-chewing.desc:8
 msgid "asdfzxcv89"
 msgstr "asdfzxcv89"
+
+#: src/fcitx-chewing.desc:12
+msgid "dstnaeo789"
+msgstr "dstnaeo789"
+
+#: src/fcitx-chewing.desc:49
+msgid "Carpalx Keyboard"
+msgstr "Carpalx Tastatur"

--- a/po/fcitx-chewing.pot
+++ b/po/fcitx-chewing.pot
@@ -17,10 +17,10 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/eim.c:143 src/chewing.conf.in:3 src/fcitx-chewing.conf.in:3
-#: src/fcitx-chewing.desc:1 src/fcitx-chewing.desc:13
-#: src/fcitx-chewing.desc:18 src/fcitx-chewing.desc:23
-#: src/fcitx-chewing.desc:28 src/fcitx-chewing.desc:33
+#: src/eim.c:149 src/chewing.conf.in:3 src/fcitx-chewing.conf.in:3
+#: src/fcitx-chewing.desc:1 src/fcitx-chewing.desc:14
+#: src/fcitx-chewing.desc:19 src/fcitx-chewing.desc:24
+#: src/fcitx-chewing.desc:29 src/fcitx-chewing.desc:34
 msgid "Chewing"
 msgstr ""
 
@@ -56,62 +56,70 @@ msgstr ""
 msgid "1234qweras"
 msgstr ""
 
-#: src/fcitx-chewing.desc:15
+#: src/fcitx-chewing.desc:12
+msgid "dstnaeo789"
+msgstr ""
+
+#: src/fcitx-chewing.desc:16
 msgid "Add Phrase Forward"
 msgstr ""
 
-#: src/fcitx-chewing.desc:20
+#: src/fcitx-chewing.desc:21
 msgid "Backward phrase choice"
 msgstr ""
 
-#: src/fcitx-chewing.desc:25
+#: src/fcitx-chewing.desc:26
 msgid "Automatically shift cursor"
 msgstr ""
 
-#: src/fcitx-chewing.desc:30
+#: src/fcitx-chewing.desc:31
 msgid "Space as selection key"
 msgstr ""
 
-#: src/fcitx-chewing.desc:35
+#: src/fcitx-chewing.desc:36
 msgid "Keyboard Layout"
 msgstr ""
 
-#: src/fcitx-chewing.desc:38
+#: src/fcitx-chewing.desc:39
 msgid "Default Keyboard"
 msgstr ""
 
-#: src/fcitx-chewing.desc:39
+#: src/fcitx-chewing.desc:40
 msgid "Hsu's Keyboard"
 msgstr ""
 
-#: src/fcitx-chewing.desc:40
+#: src/fcitx-chewing.desc:41
 msgid "IBM Keyboard"
 msgstr ""
 
-#: src/fcitx-chewing.desc:41
+#: src/fcitx-chewing.desc:42
 msgid "Gin-Yieh Keyboard"
 msgstr ""
 
-#: src/fcitx-chewing.desc:42
+#: src/fcitx-chewing.desc:43
 msgid "ETen Keyboard"
 msgstr ""
 
-#: src/fcitx-chewing.desc:43
+#: src/fcitx-chewing.desc:44
 msgid "ETen26 Keyboard"
 msgstr ""
 
-#: src/fcitx-chewing.desc:44
+#: src/fcitx-chewing.desc:45
 msgid "Dvorak Keyboard"
 msgstr ""
 
-#: src/fcitx-chewing.desc:45
+#: src/fcitx-chewing.desc:46
 msgid "Dvorak Keyboard with Hsu's support"
 msgstr ""
 
-#: src/fcitx-chewing.desc:46
+#: src/fcitx-chewing.desc:47
 msgid "DACHEN_CP26 Keyboard"
 msgstr ""
 
-#: src/fcitx-chewing.desc:47
+#: src/fcitx-chewing.desc:48
 msgid "Han-Yu PinYin Keyboard"
+msgstr ""
+
+#: src/fcitx-chewing.desc:49
+msgid "Carpalx Keyboard"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -27,22 +27,22 @@ msgstr "1234567890"
 msgid "1234qweras"
 msgstr "1234qweras"
 
-#: src/fcitx-chewing.desc:15
+#: src/fcitx-chewing.desc:16
 msgid "Add Phrase Forward"
 msgstr ""
 
-#: src/fcitx-chewing.desc:25
+#: src/fcitx-chewing.desc:26
 msgid "Automatically shift cursor"
 msgstr ""
 
-#: src/fcitx-chewing.desc:20
+#: src/fcitx-chewing.desc:21
 msgid "Backward phrase choice"
 msgstr ""
 
-#: src/eim.c:148 src/chewing.conf.in:3 src/fcitx-chewing.conf.in:3
-#: src/fcitx-chewing.desc:1 src/fcitx-chewing.desc:13 src/fcitx-chewing.desc:18
-#: src/fcitx-chewing.desc:23 src/fcitx-chewing.desc:28
-#: src/fcitx-chewing.desc:33
+#: src/eim.c:149 src/chewing.conf.in:3 src/fcitx-chewing.conf.in:3
+#: src/fcitx-chewing.desc:1 src/fcitx-chewing.desc:14 src/fcitx-chewing.desc:19
+#: src/fcitx-chewing.desc:24 src/fcitx-chewing.desc:29
+#: src/fcitx-chewing.desc:34
 msgid "Chewing"
 msgstr ""
 
@@ -50,47 +50,47 @@ msgstr ""
 msgid "Chewing Wrapper For Fcitx"
 msgstr ""
 
-#: src/fcitx-chewing.desc:46
+#: src/fcitx-chewing.desc:47
 msgid "DACHEN_CP26 Keyboard"
 msgstr "DACHEN_CP26 キーボード"
 
-#: src/fcitx-chewing.desc:38
+#: src/fcitx-chewing.desc:39
 msgid "Default Keyboard"
 msgstr "既定のキーボード"
 
-#: src/fcitx-chewing.desc:44
+#: src/fcitx-chewing.desc:45
 msgid "Dvorak Keyboard"
 msgstr "Dvorak キーボード"
 
-#: src/fcitx-chewing.desc:45
+#: src/fcitx-chewing.desc:46
 msgid "Dvorak Keyboard with Hsu's support"
 msgstr "Hsu サポートの Dvorak キーボード"
 
-#: src/fcitx-chewing.desc:42
+#: src/fcitx-chewing.desc:43
 msgid "ETen Keyboard"
 msgstr "Eten キーボード"
 
-#: src/fcitx-chewing.desc:43
+#: src/fcitx-chewing.desc:44
 msgid "ETen26 Keyboard"
 msgstr "Eten26 キーボード"
 
-#: src/fcitx-chewing.desc:41
+#: src/fcitx-chewing.desc:42
 msgid "Gin-Yieh Keyboard"
 msgstr "Gin-Yieh キーボード"
 
-#: src/fcitx-chewing.desc:47
+#: src/fcitx-chewing.desc:48
 msgid "Han-Yu PinYin Keyboard"
 msgstr "Han-Yu PinYin キーボード"
 
-#: src/fcitx-chewing.desc:39
+#: src/fcitx-chewing.desc:40
 msgid "Hsu's Keyboard"
 msgstr "Hsu キーボード"
 
-#: src/fcitx-chewing.desc:40
+#: src/fcitx-chewing.desc:41
 msgid "IBM Keyboard"
 msgstr "IBM キーボード"
 
-#: src/fcitx-chewing.desc:35
+#: src/fcitx-chewing.desc:36
 msgid "Keyboard Layout"
 msgstr "キーボードレイアウト"
 
@@ -98,7 +98,7 @@ msgstr "キーボードレイアウト"
 msgid "Selection Key"
 msgstr "選択キー"
 
-#: src/fcitx-chewing.desc:30
+#: src/fcitx-chewing.desc:31
 msgid "Space as selection key"
 msgstr "スペースを選択キーとして使う"
 
@@ -117,3 +117,11 @@ msgstr "asdfjkl789"
 #: src/fcitx-chewing.desc:8
 msgid "asdfzxcv89"
 msgstr "asdfzxcv89"
+
+#: src/fcitx-chewing.desc:12
+msgid "dstnaeo789"
+msgstr "dstnaeo789"
+
+#: src/fcitx-chewing.desc:49
+msgid "Carpalx Keyboard"
+msgstr "Carpalx キーボード"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -28,22 +28,22 @@ msgstr "1234567890"
 msgid "1234qweras"
 msgstr "1234qweras"
 
-#: src/fcitx-chewing.desc:15
+#: src/fcitx-chewing.desc:16
 msgid "Add Phrase Forward"
 msgstr "前方加词"
 
-#: src/fcitx-chewing.desc:25
+#: src/fcitx-chewing.desc:26
 msgid "Automatically shift cursor"
 msgstr "选词完毕自动移到下一个词"
 
-#: src/fcitx-chewing.desc:20
+#: src/fcitx-chewing.desc:21
 msgid "Backward phrase choice"
 msgstr "后方选择字词"
 
-#: src/eim.c:148 src/chewing.conf.in:3 src/fcitx-chewing.conf.in:3
-#: src/fcitx-chewing.desc:1 src/fcitx-chewing.desc:13 src/fcitx-chewing.desc:18
-#: src/fcitx-chewing.desc:23 src/fcitx-chewing.desc:28
-#: src/fcitx-chewing.desc:33
+#: src/eim.c:149 src/chewing.conf.in:3 src/fcitx-chewing.conf.in:3
+#: src/fcitx-chewing.desc:1 src/fcitx-chewing.desc:14 src/fcitx-chewing.desc:19
+#: src/fcitx-chewing.desc:24 src/fcitx-chewing.desc:29
+#: src/fcitx-chewing.desc:34
 msgid "Chewing"
 msgstr "新酷音"
 
@@ -51,47 +51,47 @@ msgstr "新酷音"
 msgid "Chewing Wrapper For Fcitx"
 msgstr "Fcitx 的 新酷音封装"
 
-#: src/fcitx-chewing.desc:46
+#: src/fcitx-chewing.desc:47
 msgid "DACHEN_CP26 Keyboard"
 msgstr "大千26键键盘"
 
-#: src/fcitx-chewing.desc:38
+#: src/fcitx-chewing.desc:39
 msgid "Default Keyboard"
 msgstr "默认键盘"
 
-#: src/fcitx-chewing.desc:44
+#: src/fcitx-chewing.desc:45
 msgid "Dvorak Keyboard"
 msgstr "Dvorak键盘"
 
-#: src/fcitx-chewing.desc:45
+#: src/fcitx-chewing.desc:46
 msgid "Dvorak Keyboard with Hsu's support"
 msgstr "Dvorak键盘 + 许氏注音"
 
-#: src/fcitx-chewing.desc:42
+#: src/fcitx-chewing.desc:43
 msgid "ETen Keyboard"
 msgstr "倚天键盘"
 
-#: src/fcitx-chewing.desc:43
+#: src/fcitx-chewing.desc:44
 msgid "ETen26 Keyboard"
 msgstr "倚天26键键盘"
 
-#: src/fcitx-chewing.desc:41
+#: src/fcitx-chewing.desc:42
 msgid "Gin-Yieh Keyboard"
 msgstr "精业键盘"
 
-#: src/fcitx-chewing.desc:47
+#: src/fcitx-chewing.desc:48
 msgid "Han-Yu PinYin Keyboard"
 msgstr "汉语拼音键盘"
 
-#: src/fcitx-chewing.desc:39
+#: src/fcitx-chewing.desc:40
 msgid "Hsu's Keyboard"
 msgstr "许氏键盘"
 
-#: src/fcitx-chewing.desc:40
+#: src/fcitx-chewing.desc:41
 msgid "IBM Keyboard"
 msgstr "IBM键盘"
 
-#: src/fcitx-chewing.desc:35
+#: src/fcitx-chewing.desc:36
 msgid "Keyboard Layout"
 msgstr "键盘布局"
 
@@ -99,7 +99,7 @@ msgstr "键盘布局"
 msgid "Selection Key"
 msgstr "选词键"
 
-#: src/fcitx-chewing.desc:30
+#: src/fcitx-chewing.desc:31
 msgid "Space as selection key"
 msgstr "空格键选词"
 
@@ -118,3 +118,11 @@ msgstr "asdfjkl789"
 #: src/fcitx-chewing.desc:8
 msgid "asdfzxcv89"
 msgstr "asdfzxcv89"
+
+#: src/fcitx-chewing.desc:12
+msgid "dstnaeo789"
+msgstr "dstnaeo789"
+
+#: src/fcitx-chewing.desc:49
+msgid "Carpalx Keyboard"
+msgstr "Carpalx键盘"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -30,22 +30,22 @@ msgstr "1234567890"
 msgid "1234qweras"
 msgstr "1234qweras"
 
-#: src/fcitx-chewing.desc:15
+#: src/fcitx-chewing.desc:16
 msgid "Add Phrase Forward"
 msgstr "前方加詞"
 
-#: src/fcitx-chewing.desc:25
+#: src/fcitx-chewing.desc:26
 msgid "Automatically shift cursor"
 msgstr "選字完畢自動移到下一個字"
 
-#: src/fcitx-chewing.desc:20
+#: src/fcitx-chewing.desc:21
 msgid "Backward phrase choice"
 msgstr "後方選擇字詞"
 
-#: src/eim.c:148 src/chewing.conf.in:3 src/fcitx-chewing.conf.in:3
-#: src/fcitx-chewing.desc:1 src/fcitx-chewing.desc:13 src/fcitx-chewing.desc:18
-#: src/fcitx-chewing.desc:23 src/fcitx-chewing.desc:28
-#: src/fcitx-chewing.desc:33
+#: src/eim.c:149 src/chewing.conf.in:3 src/fcitx-chewing.conf.in:3
+#: src/fcitx-chewing.desc:1 src/fcitx-chewing.desc:14 src/fcitx-chewing.desc:19
+#: src/fcitx-chewing.desc:24 src/fcitx-chewing.desc:29
+#: src/fcitx-chewing.desc:34
 msgid "Chewing"
 msgstr "新酷音"
 
@@ -53,47 +53,47 @@ msgstr "新酷音"
 msgid "Chewing Wrapper For Fcitx"
 msgstr "Fcitx 的新酷音封装"
 
-#: src/fcitx-chewing.desc:46
+#: src/fcitx-chewing.desc:47
 msgid "DACHEN_CP26 Keyboard"
 msgstr "大千26鍵"
 
-#: src/fcitx-chewing.desc:38
+#: src/fcitx-chewing.desc:39
 msgid "Default Keyboard"
 msgstr "預設鍵盤"
 
-#: src/fcitx-chewing.desc:44
+#: src/fcitx-chewing.desc:45
 msgid "Dvorak Keyboard"
 msgstr "Dvorak 鍵盤"
 
-#: src/fcitx-chewing.desc:45
+#: src/fcitx-chewing.desc:46
 msgid "Dvorak Keyboard with Hsu's support"
 msgstr "Dvorak 鍵盤 + 許氏注音"
 
-#: src/fcitx-chewing.desc:42
+#: src/fcitx-chewing.desc:43
 msgid "ETen Keyboard"
 msgstr "倚天鍵盤"
 
-#: src/fcitx-chewing.desc:43
+#: src/fcitx-chewing.desc:44
 msgid "ETen26 Keyboard"
 msgstr "倚天26鍵鍵盤"
 
-#: src/fcitx-chewing.desc:41
+#: src/fcitx-chewing.desc:42
 msgid "Gin-Yieh Keyboard"
 msgstr "精業鍵盤"
 
-#: src/fcitx-chewing.desc:47
+#: src/fcitx-chewing.desc:48
 msgid "Han-Yu PinYin Keyboard"
 msgstr "漢語拼音排列"
 
-#: src/fcitx-chewing.desc:39
+#: src/fcitx-chewing.desc:40
 msgid "Hsu's Keyboard"
 msgstr "許氏鍵盤"
 
-#: src/fcitx-chewing.desc:40
+#: src/fcitx-chewing.desc:41
 msgid "IBM Keyboard"
 msgstr "IBM 鍵盤"
 
-#: src/fcitx-chewing.desc:35
+#: src/fcitx-chewing.desc:36
 msgid "Keyboard Layout"
 msgstr "鍵盤配置"
 
@@ -101,7 +101,7 @@ msgstr "鍵盤配置"
 msgid "Selection Key"
 msgstr "選詞鍵"
 
-#: src/fcitx-chewing.desc:30
+#: src/fcitx-chewing.desc:31
 msgid "Space as selection key"
 msgstr "使用空白鍵選擇候選字詞"
 
@@ -120,3 +120,11 @@ msgstr "asdfjkl789"
 #: src/fcitx-chewing.desc:8
 msgid "asdfzxcv89"
 msgstr "asdfzxcv89"
+
+#: src/fcitx-chewing.desc:12
+msgid "dstnaeo789"
+msgstr "dstnaeo789"
+
+#: src/fcitx-chewing.desc:49
+msgid "Carpalx Keyboard"
+msgstr "Carpalx 鍵盤"

--- a/src/eim.c
+++ b/src/eim.c
@@ -82,7 +82,8 @@ const char *builtin_keymaps[] = {
     "KB_DVORAK",
     "KB_DVORAK_HSU",
     "KB_DACHEN_CP26",
-    "KB_HANYU_PINYIN"
+    "KB_HANYU_PINYIN",
+    "KB_CARPALX"
 };
 
 /**
@@ -297,6 +298,7 @@ DIGIT_STR_CHOOSE,
 "asdfjkl789",
 "aoeuhtn789",
 "1234qweras",
+"dstnaeo789",
 };
 
 /**

--- a/src/fcitx-chewing.desc
+++ b/src/fcitx-chewing.desc
@@ -2,13 +2,14 @@
 Type=Enum
 Description=Selection Key
 DefaultValue=1234567890
-EnumCount=6
+EnumCount=7
 Enum0=1234567890
 Enum1=asdfghjkl;
 Enum2=asdfzxcv89
 Enum3=asdfjkl789
 Enum4=aoeuhtn789
 Enum5=1234qweras
+Enum6=dstnaeo789
 
 [Chewing/AddPhraseForward]
 Type=Boolean
@@ -34,7 +35,7 @@ DefaultValue=True
 Type=Enum
 Description=Keyboard Layout
 DefaultValue=Default Keyboard
-EnumCount=10
+EnumCount=11
 Enum0=Default Keyboard
 Enum1=Hsu's Keyboard
 Enum2=IBM Keyboard
@@ -45,6 +46,7 @@ Enum6=Dvorak Keyboard
 Enum7=Dvorak Keyboard with Hsu's support
 Enum8=DACHEN_CP26 Keyboard
 Enum9=Han-Yu PinYin Keyboard
+Enum10=Carpalx Keyboard
 
 [DescriptionFile]
 LocaleDomain=fcitx-chewing


### PR DESCRIPTION
The Carpalx keyboard layout was recently accepted into libchewing:

[libchewing Carpalx commit](https://github.com/chewing/libchewing/commit/9ae6594c0cd1d2743cbac713906afeed69deedac)

I am submitting a PR to add this layout to fcitx. I have tested these changes on my machine and when using the git version of libchewing it works perfectly. When using an older version of libchewing that does not yet have the layout added, it still works, however the layout defaults to QWERTY, which does not break anything and is acceptable until a new release of libchewing is out.

Thanks!
